### PR TITLE
メッセージの表示形式修正、READMEに補足追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 使い方
 ------
 
-1. https://dev.twitter.com/ で適当なプロジェクトを作成
+1. https://dev.twitter.com/ でManage Your Appsから適当なプロジェクトを作成
+  Keys and AccessTokenからAccess levelをDirectMessageを許可するように修正し、アクセストークンを作成しておく
 2. jarを作成
   cloneした後、EclipseでインポートしてRunnable JAR fileでjarを生成
 3. 作成したjarを適当な箇所に配置
   /home/hogehoge/twitter_notifier.jarに置いたとする
 4. twitter4j.properties, search.propertiesをjarと同じ場所に置き、項目を埋める
+  ※accessToken、accessTokenSecretは冒頭にタブが入るのが正しいので注意
 5. cronで定期的に呼ばれるようにする
   10分ごとに実行する例
     */10 * * * * java -jar /home/hogehoge/twitter_notifier.jar

--- a/src/main/java/tsyki/twitter/notifier/TwitterNotifier.java
+++ b/src/main/java/tsyki/twitter/notifier/TwitterNotifier.java
@@ -10,6 +10,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -39,10 +41,12 @@ public class TwitterNotifier {
 	private static final String KEY_KEYWORD = "keyword";
 
 	private String confFileName;
-	
+
 	private String sinceIdFileName;
 
 	private List<String> keywords = new ArrayList<>();
+
+	private DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
 
 	/** 検索開始ID*/
 	private Long sinceId;
@@ -98,9 +102,11 @@ public class TwitterNotifier {
 				return -o1.getCreatedAt().compareTo(o2.getCreatedAt());
 			}
 		});
+		int n = 1;
 	    for (Status status : sorted) {
 	    	// ツイートへのリンク+作成日時+テキスト
-	    	String msg = getTweetUrl(status.getUser().getScreenName(), status.getId()) + " " + status.getCreatedAt() + " " + status.getText().replace("\n", " ");
+	    	// NOTE 先頭をツイートへのURLにすると、公式アプリで見た時に最初の行のツイートだけ展開されて表示されてしまうので行頭に番号を入れてそれを避ける
+	    	String msg = (n++) + ". " + getTweetUrl(status.getUser().getScreenName(), status.getId()) + " " + dateFormat.format(status.getCreatedAt()) + " " + status.getText().replace("\n", " ");
 	    	logger.info("hit:" + msg);
 	    	msgs.add(msg);
 	    }


### PR DESCRIPTION
- 作成日時をyyyy/MM/dd HH:mm:ssで表示するように
- メッセージ行の先頭に番号をつけ、勝手にリンク先ツイートが表示されないようにした  
  公式アプリでDMを見ると、最初の行のツイートの内容が展開されて表示されていたので
